### PR TITLE
fixed issue that prevented mouse wheel from scrolling multiline tabs

### DIFF
--- a/src/content/tabkit.ts
+++ b/src/content/tabkit.ts
@@ -501,7 +501,10 @@
 
     this.VerticalTabBarScrollbar = this.VerticalTabBarScrollbar || {}
     this.VerticalTabBarScrollbar.getElement = function () {
-      if (!tk.TabBar.Mode.getIsVerticalMode()) {
+      if (!tk.TabBar.Mode.getIsVerticalMode() && !(
+        (_prefs.getIntPref("tabbarPosition") === tk.Positions.TOP ||
+         _prefs.getIntPref("tabbarPosition") === tk.Positions.BOTTOM) &&
+         _prefs.getIntPref("tabRows")) > 1) {
         return null
       }
 


### PR DESCRIPTION
I had been experiencing an issue in my browser setup where the tab bar could be vertically scrolled by clicking and dragging the scroll bar, but doing the same was _not_ possible via the mouse wheel.

I eventually diagnosed this issue as stemming from the Tabkit extension; the section of code that handles tab bar scrolling relies on a variable that's set to null for configurations other than tab tree mode, and with a null value for that variable, the error checking logic that includes [this line](https://github.com/tabkit/tabkit2/blob/master/src/content/tabkit.ts#L6815) gets triggered.  I added in additional logic to set this variable to a non-null value for multiline tab mode as well, which lets the tab bar scroll correctly.

It's possible that this entire code block could be removed without negative repercussions, so long as an XML element with the box-inherit and scrollbox-innerbox classes always exists regardless of configuration settings. I have not dug into the code to check whether or not this is the case.